### PR TITLE
Update base.loadbalancer.template.json

### DIFF
--- a/PI-System-Deployment-Samples/Azure/nested/base/base.loadbalancer.template.json
+++ b/PI-System-Deployment-Samples/Azure/nested/base/base.loadbalancer.template.json
@@ -66,6 +66,10 @@
           "name": "[concat(parameters('namePrefix'),'-piaf-intlb',parameters('nameSuffix0'))]",
           "apiVersion": "[variables('apiVersions').loadBalancers]",
           "location": "[resourceGroup().location]",
+          "sku": {
+            "name": "Standard",
+            "tier": "Regional"
+          },
           "properties": {
             "frontendIPConfigurations": [
               {
@@ -450,6 +454,10 @@
             "name": "[concat(parameters('namePrefix'),'-sql-intlb',parameters('nameSuffix0'))]",
             "apiVersion": "[variables('apiVersions').loadBalancers]",
             "location": "[resourceGroup().location]",
+            "sku": {
+            "name": "Standard",
+            "tier": "Regional"
+            },
             "properties": {
                 "frontendIPConfigurations": [
                     {


### PR DESCRIPTION
New Azure rules a mix of standard and basic sku's not allowed for Lb and Public IP. Needs to be standard for scripts to deploy.

https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm