### PR TITLE
Update base.loadbalancer.staticip.template.json

### DIFF
--- a/PI-System-Deployment-Samples/Azure/nested/base/base.loadbalancer.staticip.template.json
+++ b/PI-System-Deployment-Samples/Azure/nested/base/base.loadbalancer.staticip.template.json
@@ -26,6 +26,10 @@
             "name": "[parameters('lbName')]",
             "apiVersion": "[variables('apiVersions').loadBalancers]",
             "location": "[resourceGroup().location]",
+            "sku": {
+              "name": "Standard",
+              "tier": "Regional"
+            },
             "properties": {
                 "frontendIPConfigurations": [
                     {


### PR DESCRIPTION
Azure does not allow to mix basic and standard SKU for LB and public IP. Needs to adjust for scripts to run

https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm